### PR TITLE
Fix the typo on production build for firefox

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ develop build for firefox: `npm run dev:firefox`
 
 production build for chrome: `npm run build:chrome`
 
-production build for firefox: `npm run build: chrome`
+production build for firefox: `npm run build:firefox`
 
 ## pack to .zip file
 


### PR DESCRIPTION
### 解决的问题

It is a mistake that the `npm run build:chrome` building for firefox extension.

### 描述发生的改变

Fix the typo on production build for firefox.