### PR TITLE
Remove the pronounce menu item to avoid a cascade menu.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.crx
 *.pem
 npm-debug.log
+
+.DS_Store

--- a/src/background.js
+++ b/src/background.js
@@ -64,12 +64,6 @@ chrome.runtime.onInstalled.addListener(function(details) {
     });
 
     chrome.contextMenus.create({
-        id: "pronounce",
-        title: chrome.i18n.getMessage("Pronounce") + " '%s'",
-        contexts: ["selection"]
-    });
-
-    chrome.contextMenus.create({
         id: "shortcut",
         title: chrome.i18n.getMessage("ShortcutSetting"),
         contexts: ["browser_action"]
@@ -205,12 +199,6 @@ chrome.runtime.onStartup.addListener(function() {
     chrome.contextMenus.create({
         id: "translate",
         title: chrome.i18n.getMessage("Translate") + " '%s'",
-        contexts: ["selection"]
-    });
-
-    chrome.contextMenus.create({
-        id: "pronounce",
-        title: chrome.i18n.getMessage("Pronounce") + " '%s'",
         contexts: ["selection"]
     });
 


### PR DESCRIPTION
### 解决的问题
当contextMenu多于一项时，菜单被层叠，使翻译需要多一次展开层叠菜单的交互，体验不好。
### 描述发生的改变
除去“pronounce”菜单项后，contextMenu直接显示“翻译”，少了一次点击，同时“发音”功能的体验并未变差，仍然可以在侧边通过点击喇叭来使用（去除了展开菜单操作但多了点击喇叭的操作）