### PR TITLE
feat: auto inject Vimium C

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -77,6 +77,5 @@
         "open_in_tab": true,
         "chrome_style": false
     },
-    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
     "manifest_version": 2
 }

--- a/src/manifest_chrome.json
+++ b/src/manifest_chrome.json
@@ -25,6 +25,7 @@
             "all_frames": true
         }
     ],
+    "content_security_policy": "script-src 'self' 'unsafe-eval' chrome-extension://hfjbmagddngcpeloejdejnfgbamkjaeg/ chrome-extension://aibcglbfblnogfjhbcmmpobjhnomhcdo/; object-src 'self'",
     "minimum_chrome_version": "55",
     "homepage_url": "https://github.com/EdgeTranslate/EdgeTranslate/wiki"
 }

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -27,5 +27,6 @@
             "css": ["./content/select/select.css"],
             "all_frames": true
         }
-    ]
+    ],
+    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/static/pdf/viewer.html
+++ b/static/pdf/viewer.html
@@ -42,6 +42,7 @@ See https://github.com/adobe-type-tools/cmap-resources
   <script src="viewer.js"></script>
     <script src="../content/select/select.js"></script>
     <script src="../content/display/display.js"></script>
+    <script src="vimium-c-injector.js"></script>
 
   </head>
 

--- a/static/pdf/vimium-c-injector.js
+++ b/static/pdf/vimium-c-injector.js
@@ -53,6 +53,7 @@
     const onMark = (event) => {
         const channelElement = event.relatedTarget;
         const box = channelElement && document.getElementById("viewerContainer");
+        event.stopImmediatePropagation();
         if (!box) {
             return;
         }

--- a/static/pdf/vimium-c-injector.js
+++ b/static/pdf/vimium-c-injector.js
@@ -1,12 +1,13 @@
-"use strict";
+"use strict"; // eslint-disable-line strict
 (function () {
     /**
      * Vimium C 生命周期回调函数，在 https://github.com/gdh1995/vimium-c/blob/master/content/injected_end.ts 中调用
-     * 
+     *
      * @argument {number} action_code 1: "initing", 2: "complete", 3: "destroy"
      */
-    const VimiumCHandler = (action_code, _action_name) => {
-        if (action_code === 2) { // 初始化完成
+    const VimiumCHandler = (action_code) => {
+        if (action_code === 2) {
+            // 初始化完成
             const api = window.VApi;
             const oldScroll = api.$;
             if (typeof oldScroll === "function") {
@@ -14,13 +15,18 @@
                  * 接管滚动命令，用于全屏模式下立即翻页（忽略平滑滚动）
                  */
                 api.$ = (element, di, amount) => {
-                    if (element.id === "viewerContainer" && element.classList.contains("pdfPresentationMode")) {
-                        element.dispatchEvent(new WheelEvent("wheel", {
-                            bubbles: true,
-                            cancelable: true,
-                            composed: true,
-                            deltaY: Math.sign(amount) * 120
-                        }));
+                    if (
+                        element.id === "viewerContainer" &&
+                        element.classList.contains("pdfPresentationMode")
+                    ) {
+                        element.dispatchEvent(
+                            new WheelEvent("wheel", {
+                                bubbles: true,
+                                cancelable: true,
+                                composed: true,
+                                deltaY: Math.sign(amount) * 120,
+                            })
+                        );
                     } else {
                         oldScroll.call(this, element, di, amount);
                     }
@@ -33,23 +39,26 @@
                 const file = new URLSearchParams(location.search).get("file");
                 return file || location.href;
             };
-        } else if (action_code === 3) { // 析构
+        } else if (action_code === 3) {
+            // 析构
             window.removeEventListener("vimiumMark", onMark, true);
         }
     };
 
     /**
      * 设置或者获取“文档滚动位置”，在 https://github.com/gdh1995/vimium-c/blob/master/content/marks.ts#L10 中调用
+     *
+     * @argument {CustomEvent} event
      */
     const onMark = (event) => {
-        const channelElement = event.relatedTarget
+        const channelElement = event.relatedTarget;
         const box = channelElement && document.getElementById("viewerContainer");
         if (!box) {
             return;
         }
-        box.classList.contains("pdfPresentationMode")
-        const str = channelElement.textContent
-        if (str) { // Marks.activate
+        const str = channelElement.textContent;
+        if (str) {
+            // 对应命令 Marks.activate
             const mark = str.split(",");
             const position = [~~mark[0], ~~mark[1]];
             if (position[0] > 0 || position[1] > 0) {
@@ -57,23 +66,25 @@
                 channelElement.textContent = "";
                 event.preventDefault();
             }
-        } else { // Marks.activateCreate
+        } else {
+            // 对应命令 Marks.activateCreate
             channelElement.textContent = [box.scrollLeft, box.scrollTop];
         }
     };
 
     chrome.storage.sync.get("vimiumExtensionInjector", (result) => {
-        let injectorURL = result.vimiumExtensionInjector
+        let injectorURL = result.vimiumExtensionInjector;
         if (injectorURL === "nul" || injectorURL === "/dev/null") {
             return;
         }
         if (!injectorURL) {
-            injectorURL = /\sEdg\//.test(navigator.appVersion) ? "aibcglbfblnogfjhbcmmpobjhnomhcdo"
+            injectorURL = /\sEdg\//.test(navigator.appVersion)
+                ? "aibcglbfblnogfjhbcmmpobjhnomhcdo"
                 : "hfjbmagddngcpeloejdejnfgbamkjaeg";
             chrome.storage.sync.set({ vimiumExtensionInjector: injectorURL });
         }
         if (!injectorURL.includes("://")) {
-            injectorURL = "chrome-extension://" + injectorURL + "/lib/injector.js";
+            injectorURL = `chrome-extension://${injectorURL}/lib/injector.js`;
         }
         const script = document.createElement("script");
         script.src = injectorURL;
@@ -82,8 +93,10 @@
             // 在 https://github.com/gdh1995/vimium-c/blob/master/lib/injector.ts#L87 处定义
             const injector = window.VimiumInjector;
             if (injector) {
-                injector.cache ? VimiumCHandler(2, "") : injector.callback = VimiumCHandler;
-                window.addEventListener("vimiumMark", onMark, true)
+                injector.cache
+                    ? VimiumCHandler(2, "complete")
+                    : (injector.callback = VimiumCHandler);
+                window.addEventListener("vimiumMark", onMark, true);
             }
         };
         document.head.appendChild(script);

--- a/static/pdf/vimium-c-injector.js
+++ b/static/pdf/vimium-c-injector.js
@@ -1,0 +1,91 @@
+"use strict";
+(function () {
+    /**
+     * Vimium C 生命周期回调函数，在 https://github.com/gdh1995/vimium-c/blob/master/content/injected_end.ts 中调用
+     * 
+     * @argument {number} action_code 1: "initing", 2: "complete", 3: "destroy"
+     */
+    const VimiumCHandler = (action_code, _action_name) => {
+        if (action_code === 2) { // 初始化完成
+            const api = window.VApi;
+            const oldScroll = api.$;
+            if (typeof oldScroll === "function") {
+                /**
+                 * 接管滚动命令，用于全屏模式下立即翻页（忽略平滑滚动）
+                 */
+                api.$ = (element, di, amount) => {
+                    if (element.id === "viewerContainer" && element.classList.contains("pdfPresentationMode")) {
+                        element.dispatchEvent(new WheelEvent("wheel", {
+                            bubbles: true,
+                            cancelable: true,
+                            composed: true,
+                            deltaY: Math.sign(amount) * 120
+                        }));
+                    } else {
+                        oldScroll.call(this, element, di, amount);
+                    }
+                };
+            }
+            /**
+             * 返回 PDF 文件的 URL，用于复制网页地址等命令
+             */
+            api.u = () => {
+                const file = new URLSearchParams(location.search).get("file");
+                return file || location.href;
+            };
+        } else if (action_code === 3) { // 析构
+            window.removeEventListener("vimiumMark", onMark, true);
+        }
+    };
+
+    /**
+     * 设置或者获取“文档滚动位置”，在 https://github.com/gdh1995/vimium-c/blob/master/content/marks.ts#L10 中调用
+     */
+    const onMark = (event) => {
+        const channelElement = event.relatedTarget
+        const box = channelElement && document.getElementById("viewerContainer");
+        if (!box) {
+            return;
+        }
+        box.classList.contains("pdfPresentationMode")
+        const str = channelElement.textContent
+        if (str) { // Marks.activate
+            const mark = str.split(",");
+            const position = [~~mark[0], ~~mark[1]];
+            if (position[0] > 0 || position[1] > 0) {
+                box.scrollTo(position[0], position[1]);
+                channelElement.textContent = "";
+                event.preventDefault();
+            }
+        } else { // Marks.activateCreate
+            channelElement.textContent = [box.scrollLeft, box.scrollTop];
+        }
+    };
+
+    chrome.storage.sync.get("vimiumExtensionInjector", (result) => {
+        let injectorURL = result.vimiumExtensionInjector
+        if (injectorURL === "nul" || injectorURL === "/dev/null") {
+            return;
+        }
+        if (!injectorURL) {
+            injectorURL = /\sEdg\//.test(navigator.appVersion) ? "aibcglbfblnogfjhbcmmpobjhnomhcdo"
+                : "hfjbmagddngcpeloejdejnfgbamkjaeg";
+            chrome.storage.sync.set({ vimiumExtensionInjector: injectorURL });
+        }
+        if (!injectorURL.includes("://")) {
+            injectorURL = "chrome-extension://" + injectorURL + "/lib/injector.js";
+        }
+        const script = document.createElement("script");
+        script.src = injectorURL;
+        script.async = true;
+        script.onload = () => {
+            // 在 https://github.com/gdh1995/vimium-c/blob/master/lib/injector.ts#L87 处定义
+            const injector = window.VimiumInjector;
+            if (injector) {
+                injector.cache ? VimiumCHandler(2, "") : injector.callback = VimiumCHandler;
+                window.addEventListener("vimiumMark", onMark, true)
+            }
+        };
+        document.head.appendChild(script);
+    });
+})();


### PR DESCRIPTION
### describe the bug/feature 解决的问题或新增的功能

This commit tries injecting Vimium C to inner PDF Viewer, which is for #218 and https://github.com/gdh1995/vimium-c/issues/383 .

### summary of code change 描述发生的改变

It loads Vimium C's `lib/injector.js` on `static/pdf/viewer.html` loading, so that Vimium C will run on it.

It prefers the version of Vimium C on Edge Add-ons on MS Edge; while on Chrome it prefers the version on Chrome Web Store.

This commit only affects the PDF Viewer page, but not options page.
If there's a new text option to let users type an extension ID, then `static/pdf/vimium-c-injector.js` will use it.
