### PR TITLE
feat:SelectTranslatePosition

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -29,10 +29,12 @@ const DEFAULT_SETTINGS = {
     // Resize: determine whether the web page will resize when showing translation result
     // RTL: determine whether the text in translation block should display from right to left
     // FoldLongContent: determine whether to fold long translation content
+    // SelectTranslatePosition: then position of select translate Button 
     LayoutSettings: {
         Resize: false,
         RTL: false,
         FoldLongContent: true,
+        SelectTranslatePosition:'TopRight'
     },
     // Default settings of source language and target language
     languageSetting: { sl: "auto", tl: BROWSER_LANGUAGES_MAP[chrome.i18n.getUILanguage()] },

--- a/src/content/select/select.js
+++ b/src/content/select/select.js
@@ -31,6 +31,40 @@ let scrollingElement = window; // store the specific scrolling element. In norma
 let scrollPropertyX = "pageXOffset";
 let scrollPropertyY = "pageYOffset";
 
+// init transform Button position 默认为右上
+let XBias = 10,
+YBias = -15;
+chrome.storage.sync.get("LayoutSettings", (result) => {
+    if (!result.LayoutSettings) return;
+    let LayoutSettings = result.LayoutSettings;
+    switch(LayoutSettings.SelectTranslatePosition){
+        case "TopRight":{
+            XBias=10
+            YBias=-15
+            break
+        }
+        case "TopLeft":{
+            XBias=-35
+            YBias=-15
+            break
+        }
+        case "BottomRight":{
+            XBias=10
+            YBias=35
+            break
+        }
+        case "BottomLeft":{
+            XBias=-40
+            YBias=45
+            break
+        }
+        default :{
+            break
+        }
+    }
+    
+
+});
 // this listener activated when document content is loaded
 // to make selection button available ASAP
 window.addEventListener("DOMContentLoaded", () => {
@@ -112,21 +146,20 @@ function buttonClickHandler(event) {
  * 当鼠标选中一段文字后，调用此函数，显示出翻译按钮
  */
 function showButton(event) {
+
     // 使翻译按钮显示出来
     document.documentElement.appendChild(translateButton);
-    const XBias = 10,
-        YBias = 15;
 
     // 翻译按钮的横坐标位置: 鼠标停留位置 + x方向滚动的高度 + bias
     let XPosition = event.x + XBias;
     // 翻译按钮的纵坐标位置: 鼠标停留位置 + y方向滚动的高度 + bias
-    let YPosition = event.y - YBias - translateButton.clientHeight;
-
+    let YPosition = event.y + YBias - translateButton.clientHeight;
+    // 自定义按钮位置 不需要判定了
     // if the icon is beyond the right side of the page, we need to put the icon on the left of the cursor
-    if (XPosition + translateButton.clientWidth > document.documentElement.clientWidth)
-        XPosition = event.x - XBias - translateButton.clientWidth;
+    // if (XPosition + translateButton.clientWidth > document.documentElement.clientWidth)
+    //     XPosition = event.x - XBias - translateButton.clientWidth;
     // if the icon is above the top of the page, we need to put the icon below the cursor
-    if (YPosition <= 0) YPosition = event.y + YBias;
+    // if (YPosition <= 0) YPosition = event.y + YBias;
 
     // set the new position of the icon
     // translateButton.style.transform = "translate(" + XPosition + "px," + YPosition + "px)";

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -309,6 +309,26 @@
                                 data-i18n-name="FoldLongContentSetting"
                             ></label>
                         </div>
+                        <div class="column">
+                            <label
+                                for="select-translate-position"
+                                class="checked-label i18n"
+                                data-i18n-name="SelectTranslatePosition"
+                                data-insert-pos="afterBegin"
+                            >
+                                <select
+                                    setting-type="select"
+                                    id="select-translate-position"
+                                    value="SelectTranslatePosition"
+                                    setting-path="LayoutSettings SelectTranslatePosition"
+                                >
+                                <option value="TopRight" data-i18n-name="TopRight"  class="i18n" ></option>
+                                <option value="TopLeft" data-i18n-name="TopLeft" class="i18n"  ></option>
+                                <option value="BottomRight" data-i18n-name="BottomRight" class="i18n" ></option>
+                                <option value="BottomLeft" data-i18n-name="BottomLeft" class="i18n" ></option>
+                            </select>
+                            </label>
+                        </div>
                     </div>
                 </div>
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -47,7 +47,8 @@ window.onload = () => {
      */
     chrome.storage.sync.get((result) => {
         let inputElements = document.getElementsByTagName("input");
-        for (let element of inputElements) {
+        const selectTranslatePositionElement=document.getElementById("select-translate-position")
+        for (let element of [...inputElements,selectTranslatePositionElement]) {
             let settingItemPath = element.getAttribute("setting-path").split(/\s/g);
             let settingItemValue = getSetting(result, settingItemPath);
 
@@ -88,6 +89,16 @@ window.onload = () => {
                         saveOption(result, settingItemPath, event.target.checked);
                     };
                     break;
+                case "select":
+                    element.value=settingItemValue
+                    // update setting value
+                    element.onchange = (event) => {
+                        const ele=event.target
+                        let settingItemPath = event.target
+                            .getAttribute("setting-path")
+                            .split(/\s/g);
+                        saveOption(result, settingItemPath, ele.options[ele.selectedIndex].value);
+                    };
                 default:
                     break;
             }

--- a/static/_locales/en/messages.json
+++ b/static/_locales/en/messages.json
@@ -279,6 +279,26 @@
         "message": "Settings",
         "description": "Settings"
     },
+    "SelectTranslatePosition":{
+        "message":"Select the translation button location：",
+        "description": "Select the translation button location"
+    },
+    "TopRight":{
+        "message":"Upper right",
+        "description": "Upper right"
+    },
+    "TopLeft":{
+        "message":"Upper left",
+        "description": "Upper left"
+    },
+    "BottomRight":{
+        "message":"lower right",
+        "description": "lower right"
+    },
+    "BottomLeft":{
+        "message":"Lower left",
+        "description": "Lower left"
+    },
     "SettingsTitle": {
         "message": "EdgeTranslate Settings",
         "description": "EdgeTranslate settings page"

--- a/static/_locales/ja/messages.json
+++ b/static/_locales/ja/messages.json
@@ -279,6 +279,26 @@
         "message": "設定",
         "description": "設定"
     },
+    "SelectTranslatePosition":{
+        "message":"翻訳ボタンの場所を選択：",
+        "description": "翻訳ボタンの場所を選択"
+    },
+    "TopRight":{
+        "message":"右上",
+        "description": "右上"
+    },
+    "TopLeft":{
+        "message":"左上",
+        "description": "左上"
+    },
+    "BottomRight":{
+        "message":"右下",
+        "description": "右下"
+    },
+    "BottomLeft":{
+        "message":"左下",
+        "description": "左下"
+    },
     "SettingsTitle": {
         "message": "EdgeTranslateの設定",
         "description": "EdgeTranslateの設定ページ"

--- a/static/_locales/ru/messages.json
+++ b/static/_locales/ru/messages.json
@@ -279,6 +279,26 @@
         "message": "Настройки",
         "description": "Настройки"
     },
+    "SelectTranslatePosition":{
+        "message":"Изберете местоположението на бутона за превод：",
+        "description": "Изберете местоположението на бутона за превод"
+    },
+    "TopRight":{
+        "message":"Горе вдясно",
+        "description": "Горе вдясно"
+    },
+    "TopLeft":{
+        "message":"Горе вляво",
+        "description": "Горе вляво"
+    },
+    "BottomRight":{
+        "message":"долно дясно",
+        "description": "долно дясно"
+    },
+    "BottomLeft":{
+        "message":"Долно ляво",
+        "description": "Долно ляво"
+    },
     "SettingsTitle": {
         "message": "Настройки Edge Translate",
         "description": "Страница настроек Edge Translate"

--- a/static/_locales/zh_CN/messages.json
+++ b/static/_locales/zh_CN/messages.json
@@ -279,6 +279,26 @@
         "message": "设置",
         "description": "设置"
     },
+    "SelectTranslatePosition":{
+        "message":"选中翻译按钮位置：",
+        "description": "选中翻译按钮位置"
+    },
+    "TopRight":{
+        "message":"右上",
+        "description": "右上"
+    },
+    "TopLeft":{
+        "message":"左上",
+        "description": "左上"
+    },
+    "BottomRight":{
+        "message":"右下",
+        "description": "右下"
+    },
+    "BottomLeft":{
+        "message":"左下",
+        "description": "左下"
+    },
     "SettingsTitle": {
         "message": "侧边翻译设置",
         "description": "侧边翻译设置页面"

--- a/static/_locales/zh_TW/messages.json
+++ b/static/_locales/zh_TW/messages.json
@@ -279,6 +279,26 @@
         "message": "設置",
         "description": "設置"
     },
+    "SelectTranslatePosition":{
+        "message":"選中翻譯按鈕位置：",
+        "description": "選中翻譯按鈕位置"
+    },
+    "TopRight":{
+        "message":"右上",
+        "description": "右上"
+    },
+    "TopLeft":{
+        "message":"左上",
+        "description": "左上"
+    },
+    "BottomRight":{
+        "message":"右下",
+        "description": "右下"
+    },
+    "BottomLeft":{
+        "message":"左下",
+        "description": "左下"
+    },
     "SettingsTitle": {
         "message": "側邊翻譯設置",
         "description": "側邊翻譯設置頁面"


### PR DESCRIPTION
## edge的菜单总是挡住翻译按钮
https://github.com/EdgeTranslate/EdgeTranslate/issues/309#issue-1063233848
###  自定义翻译按钮的位置
![image](https://user-images.githubusercontent.com/58926947/161074841-c208b5bd-e353-4d96-a5ff-7a7256ca7919.png)
## 效果
### 默认右上
![image](https://user-images.githubusercontent.com/58926947/161076934-16ca4e55-9018-46b3-b01e-8d9b523c346f.png)
### 左上
![image](https://user-images.githubusercontent.com/58926947/161076255-d5a2229e-6d28-4bc3-995b-5a62d87989c6.png)
### 右下
![image](https://user-images.githubusercontent.com/58926947/161076553-2e3f5c31-d454-4ef4-a574-890ed9db8724.png)
### 左下
![image](https://user-images.githubusercontent.com/58926947/161076750-6312c49e-90c2-4189-a32c-8ba6a54e3641.png)
 
## 或者考虑用户输入偏移量？

