### PR TITLE
more precise CSP section matching

### DIFF
--- a/packages/EdgeTranslate/src/background/background.js
+++ b/packages/EdgeTranslate/src/background/background.js
@@ -405,10 +405,10 @@ chrome.webRequest.onHeadersReceived.addListener(
                           )
                           .replaceAll(
                               // Add Google Page Translate related domains.
-                              /((^|;)\s*(default-src|script-src|img-src|connect-src))/g,
+                              /((^|;)\s*(default-src|script-src|img-src|connect-src)\s+)/g,
                               // eslint-disable-next-line prefer-template
-                              "$1 translate.googleapis.com translate.google.com www.google.com www.gstatic.com " +
-                                  chrome.runtime.getURL("")
+                              "$1translate.googleapis.com translate.google.com www.google.com www.gstatic.com " +
+                                  chrome.runtime.getURL("") + " "
                           ),
                   }
                 : header


### PR DESCRIPTION
Match and replace `script-src` (and others) without matching and mangling `script-src-attr`

### describe the bug/feature 解决的问题或新增的功能

I noticed on a website that had Content-Security-Policy header with both `script-src` and `script-src-attr` the replacement incorrectly matched on and modified `script-src-attr` 

### summary of code change 描述发生的改变

Only match when whitespace is after the script-src and other sections.  Adjust whitespace in the replacement to match.  

I have tested the regex logic.  But I haven't fully tested this extension with the change, since I'm not familiar enough  extension development, so someone probably should do that.