### PR TITLE
Fix `overscroll-behavior: contain` not working

### DIFF
--- a/packages/EdgeTranslate/src/content/display/Panel.jsx
+++ b/packages/EdgeTranslate/src/content/display/Panel.jsx
@@ -726,6 +726,10 @@ const GlobalStyle = createGlobalStyle`
         background-color: rgba(150, 150, 150, 0.8);
     }
 
+    .simplebar-content-wrapper {
+        overscroll-behavior: contain;
+    }
+
     /* Apply to the content wrapper, which is the parent element of simplebar-content, to align content in the vertical center. */
     .${ContentWrapperCenterClassName} {
         display: flex;
@@ -740,7 +744,7 @@ const GlobalStyle = createGlobalStyle`
     }
 
     /* Adjust the content container, which is the parent element of Panel Body. */
-    .simplebar-content{
+    .simplebar-content {
         display: flex;
         flex-direction: column;
         justify-content: flex-start;
@@ -859,7 +863,6 @@ const Body = styled.div`
     align-items: center;
     overflow-x: hidden;
     overflow-y: overlay;
-    overscroll-behavior: contain;
     flex-grow: 1;
     flex-shrink: 1;
     word-break: break-word;


### PR DESCRIPTION
### describe the bug/feature 解决的问题或新增的功能

https://github.com/EdgeTranslate/EdgeTranslate/assets/68118705/6ce90c66-efcf-44a4-9222-ae91607f2bbf

https://github.com/EdgeTranslate/EdgeTranslate/assets/68118705/48cf59b7-30ea-4975-9a5d-959186d82885

### summary of code change 描述发生的改变

Move `overscroll-behavior: contain` to `.simplebar-content-wrapper`