### PR TITLE
fix: fix 614, 619.

### DIFF
--- a/packages/EdgeTranslate/src/content/common.js
+++ b/packages/EdgeTranslate/src/content/common.js
@@ -11,10 +11,10 @@ function isPDF() {
  * Check if current page is Chrome PDF Viewer.
  */
 function isChromePDFViewer() {
+    let href = document.location.href;
     return (
-        document.body &&
-        document.body.children[0] &&
-        document.body.children[0].type === "application/pdf"
+        href.toLowerCase().endsWith('.pdf') &&
+        !href.startsWith("chrome-extension://")
     );
 }
 

--- a/packages/EdgeTranslate/src/content/pdf.js
+++ b/packages/EdgeTranslate/src/content/pdf.js
@@ -24,7 +24,7 @@ window.addEventListener("load", () => {
          * https://www.yuque.com/.
          */
         let pdfSrc = window.location.href;
-        if (document.body.children[0].src && document.body.children[0].src !== "about:blank") {
+        if (document.body && document.body.children && document.body.children.length > 0 && document.body.children[0].src && document.body.children[0].src !== "about:blank") {
             pdfSrc = document.body.children[0].src;
         }
 


### PR DESCRIPTION
### describe the bug/feature 解决的问题或新增的功能
fixes 614, 619.
PDF content will be displayed within a shadow DOM for Chrome newer versions, so we can't query within the PDF DOMs anymore to decide if it's managed by the builtin PDF viewer. 

### summary of code change 描述发生的改变
Current workaround is to check if this is a PDF file and if it's rendered by the builtin viewer (non extension).

新版本的Chrome内置pdf浏览器在显示pdf内容时，除了`<body>`等tag的字符，整个内部pdf内容是独立的。无法再通过js查询判断是不是内置pdf浏览器`isChromePDFViewer()`.
目前的绕开方法是无脑判断文件(URL)是不是以`.pdf`结尾。并且这个URL不是插件（比如本插件）渲染的，那就说明是由内置pdf浏览器打开的了。